### PR TITLE
refactor: Rename Private Functions with Underscore Prefix

### DIFF
--- a/src/ni_measurement_plugin_packager/_support/_log_file_path.py
+++ b/src/ni_measurement_plugin_packager/_support/_log_file_path.py
@@ -4,26 +4,12 @@ from pathlib import Path, WindowsPath
 from typing import Tuple
 
 
-def get_public_documents_path() -> Path:
-    """Get Public Documents directory path.
-
-    Robust method agnostic of OS installed drive.
-
-    Returns:
-        Public Documents directory path.
-    """
+def _get_public_documents_path() -> Path:
     public_documents_path = WindowsPath("~Public") / "Documents"
     return public_documents_path.expanduser()
 
 
-def get_user_documents_path() -> Path:
-    """Get user's My Documents directory path.
-
-    Robust method agnostic of OS installed drive.
-
-    Returns:
-        User's My Documents directory path.
-    """
+def _get_user_documents_path() -> Path:
     public_documents_path = Path.home() / "Documents"
     return public_documents_path.expanduser()
 
@@ -45,11 +31,11 @@ def get_log_directory_path(fallback_path: Path) -> Tuple[Path, bool, bool]:
     user_path_status = True
 
     try:
-        log_directory_path = get_public_documents_path()
+        log_directory_path = _get_public_documents_path()
     except Exception:
         public_path_status = False
         try:
-            log_directory_path = get_user_documents_path()
+            log_directory_path = _get_user_documents_path()
         except Exception:
             user_path_status = False
             log_directory_path = fallback_path

--- a/src/ni_measurement_plugin_packager/_support/_logger.py
+++ b/src/ni_measurement_plugin_packager/_support/_logger.py
@@ -50,13 +50,12 @@ def _setup_stream_handler() -> StreamHandler:
     return handler
 
 
-def add_file_handler(logger: Logger, log_directory_path: Path) -> None:
-    """Add a file handler to the logger for logging to a file.
+def _add_stream_handler(logger: Logger) -> None:
+    stream_handler = _setup_stream_handler()
+    logger.addHandler(stream_handler)
 
-    Args:
-        logger: Logger object.
-        log_directory_path: Log directory path.
-    """
+
+def _add_file_handler(logger: Logger, log_directory_path: Path) -> None:
     handler = _setup_file_handler(log_directory_path=log_directory_path, file_name=LOG_FILE_NAME)
     logger.addHandler(handler)
 
@@ -72,7 +71,7 @@ def setup_logger_with_file_handler(fallback_path: Path, logger: Logger) -> Tuple
         Logger object and logger directory path.
     """
     log_directory_path, public_path_status, user_path_status = get_log_directory_path(fallback_path)
-    add_file_handler(logger=logger, log_directory_path=log_directory_path)
+    _add_file_handler(logger=logger, log_directory_path=log_directory_path)
 
     if not public_path_status:
         logger.info(StatusMessages.PUBLIC_DIRECTORY_INACCESSIBLE)
@@ -80,16 +79,6 @@ def setup_logger_with_file_handler(fallback_path: Path, logger: Logger) -> Tuple
         logger.info(StatusMessages.USER_DIRECTORY_INACCESSIBLE)
 
     return logger, log_directory_path
-
-
-def add_stream_handler(logger: Logger) -> None:
-    """Add a stream handler to the logger for logging to the console.
-
-    Args:
-        logger: Logger object.
-    """
-    stream_handler = _setup_stream_handler()
-    logger.addHandler(stream_handler)
 
 
 def initialize_logger(name: str) -> Logger:
@@ -104,7 +93,7 @@ def initialize_logger(name: str) -> Logger:
     new_logger = logging.getLogger(name)
     new_logger.setLevel(logging.DEBUG)
 
-    add_stream_handler(logger=new_logger)
+    _add_stream_handler(logger=new_logger)
     return new_logger
 
 

--- a/src/ni_measurement_plugin_packager/_support/_pyproject_toml_info.py
+++ b/src/ni_measurement_plugin_packager/_support/_pyproject_toml_info.py
@@ -19,36 +19,18 @@ DEFAULT_VERSION = "1.0.0"
 DEFAULT_AUTHOR = "National Instruments"
 
 
-def parse_pyproject_toml(toml_file_path: Path) -> Dict[str, Any]:
-    """Parse the `pyproject.toml` file for measurement plug-in data.
-
-    Args:
-        toml_file_path: File path of pyproject.toml.
-
-    Returns:
-        Pyproject toml information.
-    """
+def _parse_pyproject_toml(toml_file_path: Path) -> Dict[str, Any]:
     with open(toml_file_path, "rb") as file:
         pyproject_data = tomli.load(file)
 
     return pyproject_data
 
 
-def extract_package_metadata(
+def _extract_package_metadata(
     logger: Logger,
     toml_content: Dict[str, Any],
     plugin_name: str,
 ) -> PackageInfo:
-    """Extract updated package metadata from `pyproject.toml` content.
-
-    Args:
-        logger: Logger object.
-        toml_content: Pyproject toml data.
-        plugin_name: Measurement name.
-
-    Returns:
-        Updated measurement package info.
-    """
     package_info = toml_content[PyProjectToml.TOOL][PyProjectToml.POETRY]
     package_description = package_info[PyProjectToml.DESCRIPTION]
     package_name = package_info[PyProjectToml.NAME].lower()
@@ -100,9 +82,9 @@ def get_plugin_package_info(measurement_plugin_path: Path, logger: Logger) -> Pa
     pyproject_toml_path = Path(measurement_plugin_path) / PyProjectToml.FILE_NAME
     plugin_name = Path(measurement_plugin_path).name
 
-    pyproject_toml_data = parse_pyproject_toml(toml_file_path=pyproject_toml_path)
+    pyproject_toml_data = _parse_pyproject_toml(toml_file_path=pyproject_toml_path)
 
-    measurement_package_info = extract_package_metadata(
+    measurement_package_info = _extract_package_metadata(
         logger=logger,
         toml_content=pyproject_toml_data,
         plugin_name=plugin_name,


### PR DESCRIPTION
<!-- TODO: Mark the following with an 'x' as applicable -->
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python-packager/blob/main/CONTRIBUTING.md). _(Required)_

### What does this Pull Request accomplish?

This PR refactors the code by renaming private functions to follow the convention of prefixing them with an underscore (`_`) to indicate that they are intended for internal use only.

### Why should this Pull Request be merged?

This change aligns with Python's naming convention for private functions.

### What testing has been done?

NA.

### Checklist
- [x] Code follows coding standards
- [ ] No console logs or debug statements
- [ ] Manual tests conducted
- [x] Doesn’t break existing functionality
- [ ] Documentation updated (if applicable)
- [ ] No performance regressions (if applicable)
- [ ] Tests have been written/updated (if applicable)